### PR TITLE
Fixed UI to accompany long country names in a more visually pleasing manner

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -32,7 +32,6 @@ button {
   flex-direction: column;
   overflow: hidden;
   min-width: 480px;
-  width: 480px;
 }
 
 .app__footer {

--- a/css/styles.css
+++ b/css/styles.css
@@ -13,6 +13,7 @@ body {
   align-items: flex-start;
   justify-content: flex-end;
   font-family: 'Roboto', sans-serif;
+  background: #0e1120;
 }
 
 button {
@@ -30,7 +31,8 @@ button {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  min-width: 470px;
+  min-width: 480px;
+  width: 480px;
 }
 
 .app__footer {
@@ -44,8 +46,9 @@ button {
 
 .remove-country {
   position: absolute;
-  bottom: 14px;
+  top: 50%;
   left: -12px;
+  transform: translateY(-50%);
   width: 24px;
   height: 24px;
   background: #ff4384;
@@ -187,7 +190,7 @@ button {
 
 .country {
   display: flex;
-  align-items: center;
+  align-items: stretch;
   justify-content: flex-end;
   background: #252a3d;
   border-top-left-radius: 25px;
@@ -210,7 +213,14 @@ button {
   padding: 10px 20px;
   margin-top: 2px;
   margin-right: auto;
-  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+  max-width: 180px;
+}
+
+.country__name--small {
+  font-size: 12px;
 }
 
 .statistic {
@@ -220,6 +230,8 @@ button {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+  justify-content: center;
+  flex-shrink: 0;
 }
 
 .statistic:last-child {

--- a/js/main.js
+++ b/js/main.js
@@ -184,13 +184,17 @@ function createRow(item, itemSet) {
   const div = document.createElement('div');
   div.classList.add('country');
 
+  // If the item doesn't have a title we know it's global
+  // To prevent too many if checks below, we just set a title on Global
+  if (!itemData.title) itemData.title = 'Global';
+
   div.innerHTML = `
     <button class="${(itemData.ourid) ? 'remove-country' : 'remove-country remove-country--hidden'}" data-ourid="${itemData.ourid}">
       <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 14 14" style="enable-background:new 0 0 14 14;" xml:space="preserve">
         <path d="M14,1.4L12.6,0L7,5.6L1.4,0L0,1.4L5.6,7L0,12.6L1.4,14L7,8.4l5.6,5.6l1.4-1.4L8.4,7L14,1.4z"/>
       </svg>
     </button>
-    <div class="country__name">${itemData.title || 'Global'}</div>
+    <div class="${(itemData.title.length < 20) ? 'country__name' : 'country__name country__name--small' }">${itemData.title}</div>
     <!-- Confirmed -->
     <div class="statistic column-confirmed">
       <div class="statistic__count">${formatNumber(itemData.total_cases)}</div>


### PR DESCRIPTION
1. Names that are longer than 20 characters will appear 3 pixels smaller in size on the UI.
2. Fixed the UI to not break when long names are present without forcing them to stay on one line.