### PR TITLE
Fixed legacy global bug

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "COVID-19 Corona Virus Tracker",
-  "version": "2.0",
+  "version": "2.1",
   "description": "This Chrome Extension is a COVID-19 Corona Virus Tracker allowing you to track the world-wide spread of this pandemic.",
   "permissions": [
     "storage"

--- a/src/App.js
+++ b/src/App.js
@@ -178,12 +178,18 @@ class App extends React.Component {
           countries: getTopFourConfirmedCountries(this.state.countryData)
         };
         newUserStorage.countries = this.sortData(newUserStorage.countries, this.state.countryData, this.state.sort.column, true);
-        
+        newUserStorage.countries.splice(newUserStorage.countries.indexOf('global'), 1);
+
         this.setState({userStorage: newUserStorage});
         chrome.storage.sync.set({ 'userStorage': newUserStorage });
       }
       else {
         const newUserStorage = result.userStorage;
+
+        // For V1 users that didn't have global in their country list
+        // We manually patch global in for them
+        if (!newUserStorage.countries.includes('global')) newUserStorage.countries.push('global');
+
         newUserStorage.countries = this.sortData(newUserStorage.countries, this.state.countryData, this.state.sort.column, true);
         this.setState({userStorage: newUserStorage});
       }

--- a/src/App.js
+++ b/src/App.js
@@ -178,7 +178,6 @@ class App extends React.Component {
           countries: getTopFourConfirmedCountries(this.state.countryData)
         };
         newUserStorage.countries = this.sortData(newUserStorage.countries, this.state.countryData, this.state.sort.column, true);
-        newUserStorage.countries.splice(newUserStorage.countries.indexOf('global'), 1);
 
         this.setState({userStorage: newUserStorage});
         chrome.storage.sync.set({ 'userStorage': newUserStorage });


### PR DESCRIPTION
When an existing user get the updated app version, they won't have global in their countries list.

This happens because of a data structure change.

I put in a fix that will check to make sure the user has global, and if they don't it will add it for them.